### PR TITLE
Bug fixes (Mainly with slabs)

### DIFF
--- a/src/main/java/nl/mtvehicles/core/events/VehiclePlaceEvent.java
+++ b/src/main/java/nl/mtvehicles/core/events/VehiclePlaceEvent.java
@@ -56,6 +56,7 @@ public class VehiclePlaceEvent implements Listener {
         }
         if (Main.defaultConfig.isBlockWhitelistEnabled()
                 && !Main.defaultConfig.blockWhiteList().contains(e.getClickedBlock().getType())) {
+            e.setCancelled(true);
             Main.messagesConfig.sendMessage(p, "blockNotInWhitelist");
             return;
         }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
@@ -182,13 +182,6 @@ public class VehicleMovement1_12 {
             if (loc.getBlock().getType().toString().contains("AIR")) {
                 return;
             }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    if (data < 9) {
-                        return;
-                    }
-                }
-            }
             ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
             return;
         }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
@@ -178,24 +178,56 @@ public class VehicleMovement1_12 {
         Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
         int data = loc.getBlock().getData();
         String locY = String.valueOf(mainStand.getLocation().getY());
-        if (locY.substring(locY.length() - 2).contains(".5")) {
-            if (loc.getBlock().getType().toString().contains("AIR")) {
+        Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
+
+        if (driveUpSlabs()){
+            if (locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                    if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                        return;
+                    }
+                }
+                ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 return;
             }
             if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
                 if (loc.getBlock().getType().toString().contains("DOUBLE")) {
                     return;
                 }
+                if (data < 9) {
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                }
             }
-            ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-            return;
-        }
-        if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-            if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                return;
+        } else {
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (!loc.getBlock().getType().toString().contains("AIR")) {
+                    if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                        if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
+                            return;
+                        }
+                    }
+
+                    if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                        return;
+                    }
+
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                }
             }
-            if (data < 9) {
+            if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                    if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
+                        return;
+                    }
+                }
                 ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                return;
             }
         }
     }
@@ -274,5 +306,12 @@ public class VehicleMovement1_12 {
         final Location loc = new Location(main.getWorld(), xvp, main.getLocation().getY() + yOffset, zvp, seatas.getLocation().getYaw(), fbvp.getPitch());
         EntityArmorStand stand = ((CraftArmorStand) seatas).getHandle();
         stand.setLocation(loc.getX(), loc.getY(), loc.getZ(), seatas.getLocation().getYaw() + 15, seatas.getLocation().getPitch());
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
@@ -182,6 +182,11 @@ public class VehicleMovement1_12 {
             if (loc.getBlock().getType().toString().contains("AIR")) {
                 return;
             }
+            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                    return;
+                }
+            }
             ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
             return;
         }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
@@ -175,13 +175,6 @@ public class VehicleMovement1_13 {
                 if (loc.getBlock().getType().toString().contains("AIR")) {
                     return;
                 }
-                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                    if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                        if (data < 9) {
-                            return;
-                        }
-                    }
-                }
                 ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 return;
             }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
@@ -177,7 +177,7 @@ public class VehicleMovement1_13 {
                 }
                 if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
                     if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                        if (data == 0 || data == 5) {
+                        if (data < 9) {
                             return;
                         }
                     }
@@ -189,7 +189,7 @@ public class VehicleMovement1_13 {
                 if (loc.getBlock().getType().toString().contains("DOUBLE")) {
                     return;
                 }
-                if (data == 0 || data == 5) {
+                if (data < 9) {
                     ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 }
             }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
@@ -175,6 +175,11 @@ public class VehicleMovement1_13 {
                 if (loc.getBlock().getType().toString().contains("AIR")) {
                     return;
                 }
+                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                    if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                        return;
+                    }
+                }
                 ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 return;
             }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
@@ -6,6 +6,7 @@ import nl.mtvehicles.core.Main;
 import nl.mtvehicles.core.infrastructure.helpers.BossBarUtils;
 import nl.mtvehicles.core.infrastructure.helpers.VehicleData;
 import org.bukkit.*;
+import org.bukkit.block.data.type.Slab;
 import org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -163,32 +164,60 @@ public class VehicleMovement1_13 {
             float xvp = (float) (fbvp.getX() + zOffset * Math.cos(Math.toRadians(fbvp.getYaw())));
             Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
             int data = loc.getBlock().getData();
-            System.out.println(loc.getBlock().getType().toString() + " " + data);
             String locY = String.valueOf(mainStand.getLocation().getY());
-            if (!locY.substring(locY.length() - 2).contains(".5")) {
-                if (!loc.getBlock().isPassable() && !loc.getBlock().getType().toString().contains("STEP") && !loc.getBlock().getType().toString().contains("SLAB")) {
-                    VehicleData.speed.put(license, 0.0);
-                }
-            }
-            if (locY.substring(locY.length() - 2).contains(".5")) {
+            Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
-                if (loc.getBlock().getType().toString().contains("AIR")) {
+            if (driveUpSlabs()){
+                if (locY.substring(locY.length() - 2).contains(".5")) {
+                    if (loc.getBlock().getType().toString().contains("AIR")) {
+                        return;
+                    }
+                    if (loc.getBlock().getBlockData() instanceof Slab) {
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("BOTTOM")) {
+                            return;
+                        }
+                    }
+                    ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                     return;
                 }
-                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                    if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                if (loc.getBlock().getBlockData() instanceof Slab){
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("BOTTOM")){
+                        ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    } else {
                         return;
                     }
                 }
-                ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-                return;
-            }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    return;
+            } else {
+                if (!locY.substring(locY.length() - 2).contains(".5")) {
+                    if (!loc.getBlock().isPassable()) {
+                        if (loc.getBlock().getBlockData() instanceof Slab){
+                            Slab slab = (Slab) loc.getBlock().getBlockData();
+                            if (slab.getType().toString().equals("BOTTOM")){
+                                return;
+                            }
+                        }
+
+                        if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                            return;
+                        }
+
+                        ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    }
                 }
-                if (data < 9) {
+                if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                    if (loc.getBlock().getType().toString().contains("AIR")) {
+                        return;
+                    }
+                    if (loc.getBlock().getBlockData() instanceof Slab){
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (!slab.getType().toString().equals("DOUBLE")){
+                            return;
+                        }
+                    }
                     ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    return;
                 }
             }
         });
@@ -271,6 +300,13 @@ public class VehicleMovement1_13 {
             net.minecraft.server.v1_13_R2.EntityArmorStand stand = ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) seatas).getHandle();
             stand.setLocation(loc.getX(), loc.getY(), loc.getZ(), seatas.getLocation().getYaw() + 15, seatas.getLocation().getPitch());
         });
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
     }
 
 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
@@ -177,7 +177,7 @@ public class VehicleMovement1_14 {
                 }
                 if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
                     if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                        if (data == 0 || data == 5) {
+                        if (data < 9) {
                             return;
                         }
                     }
@@ -189,7 +189,7 @@ public class VehicleMovement1_14 {
                 if (loc.getBlock().getType().toString().contains("DOUBLE")) {
                     return;
                 }
-                if (data == 0 || data == 5) {
+                if (data < 9) {
                     ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 }
             }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
@@ -6,6 +6,7 @@ import nl.mtvehicles.core.Main;
 import nl.mtvehicles.core.infrastructure.helpers.BossBarUtils;
 import nl.mtvehicles.core.infrastructure.helpers.VehicleData;
 import org.bukkit.*;
+import org.bukkit.block.data.type.Slab;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -163,32 +164,60 @@ public class VehicleMovement1_14 {
             float xvp = (float) (fbvp.getX() + zOffset * Math.cos(Math.toRadians(fbvp.getYaw())));
             Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
             int data = loc.getBlock().getData();
-            System.out.println(loc.getBlock().getType().toString() + " " + data);
             String locY = String.valueOf(mainStand.getLocation().getY());
-            if (!locY.substring(locY.length() - 2).contains(".5")) {
-                if (!loc.getBlock().isPassable() && !loc.getBlock().getType().toString().contains("STEP") && !loc.getBlock().getType().toString().contains("SLAB")) {
-                    VehicleData.speed.put(license, 0.0);
-                }
-            }
-            if (locY.substring(locY.length() - 2).contains(".5")) {
+            Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
-                if (loc.getBlock().getType().toString().contains("AIR")) {
+            if (driveUpSlabs()){
+                if (locY.substring(locY.length() - 2).contains(".5")) {
+                    if (loc.getBlock().getType().toString().contains("AIR")) {
+                        return;
+                    }
+                    if (loc.getBlock().getBlockData() instanceof Slab) {
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("BOTTOM")) {
+                            return;
+                        }
+                    }
+                    ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                     return;
                 }
-                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                    if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                if (loc.getBlock().getBlockData() instanceof Slab){
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("BOTTOM")){
+                        ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    } else {
                         return;
                     }
                 }
-                ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-                return;
-            }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    return;
+            } else {
+                if (!locY.substring(locY.length() - 2).contains(".5")) {
+                    if (!loc.getBlock().isPassable()) {
+                        if (loc.getBlock().getBlockData() instanceof Slab){
+                            Slab slab = (Slab) loc.getBlock().getBlockData();
+                            if (slab.getType().toString().equals("BOTTOM")){
+                                return;
+                            }
+                        }
+
+                        if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                            return;
+                        }
+
+                        ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    }
                 }
-                if (data < 9) {
+                if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                    if (loc.getBlock().getType().toString().contains("AIR")) {
+                        return;
+                    }
+                    if (loc.getBlock().getBlockData() instanceof Slab){
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (!slab.getType().toString().equals("DOUBLE")){
+                            return;
+                        }
+                    }
                     ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    return;
                 }
             }
         });
@@ -271,6 +300,13 @@ public class VehicleMovement1_14 {
             net.minecraft.server.v1_14_R1.EntityArmorStand stand = ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) seatas).getHandle();
             stand.setLocation(loc.getX(), loc.getY(), loc.getZ(), seatas.getLocation().getYaw() + 15, seatas.getLocation().getPitch());
         });
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
     }
 
 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
@@ -175,13 +175,6 @@ public class VehicleMovement1_14 {
                 if (loc.getBlock().getType().toString().contains("AIR")) {
                     return;
                 }
-                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                    if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                        if (data < 9) {
-                            return;
-                        }
-                    }
-                }
                 ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 return;
             }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
@@ -175,6 +175,11 @@ public class VehicleMovement1_14 {
                 if (loc.getBlock().getType().toString().contains("AIR")) {
                     return;
                 }
+                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                    if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                        return;
+                    }
+                }
                 ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 return;
             }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
@@ -178,13 +178,6 @@ public class VehicleMovement1_15 {
             if (loc.getBlock().getType().toString().contains("AIR")) {
                 return;
             }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    if (data < 9) {
-                        return;
-                    }
-                }
-            }
             ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
             return;
         }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
@@ -178,6 +178,11 @@ public class VehicleMovement1_15 {
             if (loc.getBlock().getType().toString().contains("AIR")) {
                 return;
             }
+            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                    return;
+                }
+            }
             ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
             return;
         }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
@@ -180,7 +180,7 @@ public class VehicleMovement1_15 {
             }
             if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
                 if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    if (data == 0 || data == 5) {
+                    if (data < 9) {
                         return;
                     }
                 }
@@ -192,7 +192,7 @@ public class VehicleMovement1_15 {
             if (loc.getBlock().getType().toString().contains("DOUBLE")) {
                 return;
             }
-            if (data == 0 || data == 5) {
+            if (data < 9) {
                 ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
             }
         }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
@@ -5,10 +5,8 @@ import net.minecraft.server.v1_15_R1.PacketPlayInSteerVehicle;
 import nl.mtvehicles.core.Main;
 import nl.mtvehicles.core.infrastructure.helpers.BossBarUtils;
 import nl.mtvehicles.core.infrastructure.helpers.VehicleData;
-import org.bukkit.Effect;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Particle;
+import org.bukkit.*;
+import org.bukkit.block.data.type.Slab;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -169,29 +167,59 @@ public class VehicleMovement1_15 {
         Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
         int data = loc.getBlock().getData();
         String locY = String.valueOf(mainStand.getLocation().getY());
-        if (!locY.substring(locY.length() - 2).contains(".5")) {
-            if (!loc.getBlock().isPassable() && !loc.getBlock().getType().toString().contains("STEP") && !loc.getBlock().getType().toString().contains("SLAB")) {
-                VehicleData.speed.put(license, 0.0);
-            }
-        }
-        if (locY.substring(locY.length() - 2).contains(".5")) {
-            if (loc.getBlock().getType().toString().contains("AIR")) {
+        Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
+
+        if (driveUpSlabs()){
+            if (locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getBlockData() instanceof Slab) {
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("BOTTOM")) {
+                        return;
+                    }
+                }
+                ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 return;
             }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+            if (loc.getBlock().getBlockData() instanceof Slab){
+                Slab slab = (Slab) loc.getBlock().getBlockData();
+                if (slab.getType().toString().equals("BOTTOM")){
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                } else {
                     return;
                 }
             }
-            ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-            return;
-        }
-        if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-            if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                return;
+        } else {
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (!loc.getBlock().isPassable()) {
+                    if (loc.getBlock().getBlockData() instanceof Slab){
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("BOTTOM")){
+                            return;
+                        }
+                    }
+
+                    if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                        return;
+                    }
+
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                }
             }
-            if (data < 9) {
+            if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getBlockData() instanceof Slab){
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (!slab.getType().toString().equals("DOUBLE")){
+                        return;
+                    }
+                }
                 ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                return;
             }
         }
     }
@@ -270,5 +298,16 @@ public class VehicleMovement1_15 {
         final Location loc = new Location(main.getWorld(), xvp, main.getLocation().getY() + yOffset, zvp, seatas.getLocation().getYaw(), fbvp.getPitch());
         EntityArmorStand stand = ((CraftArmorStand) seatas).getHandle();
         stand.setLocation(loc.getX(), loc.getY(), loc.getZ(), seatas.getLocation().getYaw() + 15, seatas.getLocation().getPitch());
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
+    }
+
+    private static void debugConsoleLog(String s){
+        Bukkit.getConsoleSender().sendMessage(s);
     }
 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
@@ -186,7 +186,7 @@ public class VehicleMovement1_16 {
             }
             if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
                 if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    if (data == 0 || data == 5) {
+                    if (data < 9) {
                         return;
                     }
                 }
@@ -204,7 +204,7 @@ public class VehicleMovement1_16 {
             if (loc.getBlock().getType().toString().contains("DOUBLE")) {
                 return;
             }
-            if (data == 0 || data == 5) {
+            if (data < 9) {
                 Bukkit.getScheduler().runTask(Main.instance, () -> {
                     try {
                         ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
@@ -184,13 +184,6 @@ public class VehicleMovement1_16 {
             if (loc.getBlock().getType().toString().contains("AIR")) {
                 return;
             }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    if (data < 9) {
-                        return;
-                    }
-                }
-            }
             Bukkit.getScheduler().runTask(Main.instance, () -> {
                 try {
                     ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
@@ -184,6 +184,11 @@ public class VehicleMovement1_16 {
             if (loc.getBlock().getType().toString().contains("AIR")) {
                 return;
             }
+            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                    return;
+                }
+            }
             Bukkit.getScheduler().runTask(Main.instance, () -> {
                 try {
                     ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
@@ -182,13 +182,6 @@ public class VehicleMovement1_17 {
             if (loc.getBlock().getType().toString().contains("AIR")) {
                 return;
             }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    if (data < 9) {
-                        return;
-                    }
-                }
-            }
             Bukkit.getScheduler().runTask(Main.instance, () -> {
                 ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
             });

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
@@ -182,6 +182,11 @@ public class VehicleMovement1_17 {
             if (loc.getBlock().getType().toString().contains("AIR")) {
                 return;
             }
+            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                    return;
+                }
+            }
             Bukkit.getScheduler().runTask(Main.instance, () -> {
                 ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
             });

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
@@ -184,7 +184,7 @@ public class VehicleMovement1_17 {
             }
             if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
                 if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    if (data == 0 || data == 5) {
+                    if (data < 9) {
                         return;
                     }
                 }
@@ -198,7 +198,7 @@ public class VehicleMovement1_17 {
             if (loc.getBlock().getType().toString().contains("DOUBLE")) {
                 return;
             }
-            if (data == 0 || data == 5) {
+            if (data < 9) {
                 Bukkit.getScheduler().runTask(Main.instance, () -> {
                     ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 });

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
@@ -6,6 +6,7 @@ import nl.mtvehicles.core.Main;
 import nl.mtvehicles.core.infrastructure.helpers.BossBarUtils;
 import nl.mtvehicles.core.infrastructure.helpers.VehicleData;
 import org.bukkit.*;
+import org.bukkit.block.data.type.Slab;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -173,33 +174,67 @@ public class VehicleMovement1_17 {
         Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
         int data = loc.getBlock().getData();
         String locY = String.valueOf(mainStand.getLocation().getY());
-        if (!locY.substring(locY.length() - 2).contains(".5")) {
-            if (!loc.getBlock().isPassable() && !loc.getBlock().getType().toString().contains("STEP") && !loc.getBlock().getType().toString().contains("SLAB")) {
-                VehicleData.speed.put(license, 0.0);
-            }
-        }
-        if (locY.substring(locY.length() - 2).contains(".5")) {
-            if (loc.getBlock().getType().toString().contains("AIR")) {
-                return;
-            }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+        Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
+
+        if (driveUpSlabs()){
+            if (locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getType().toString().contains("AIR")) {
                     return;
                 }
-            }
-            Bukkit.getScheduler().runTask(Main.instance, () -> {
-                ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-            });
-            return;
-        }
-        if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-            if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                return;
-            }
-            if (data < 9) {
+                if (loc.getBlock().getBlockData() instanceof Slab) {
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("BOTTOM")) {
+                        return;
+                    }
+                }
                 Bukkit.getScheduler().runTask(Main.instance, () -> {
                     ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 });
+                return;
+            }
+            if (loc.getBlock().getBlockData() instanceof Slab){
+                Slab slab = (Slab) loc.getBlock().getBlockData();
+                if (slab.getType().toString().equals("BOTTOM")){
+                    Bukkit.getScheduler().runTask(Main.instance, () -> {
+                        ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    });
+                } else {
+                    return;
+                }
+            }
+        } else {
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (!loc.getBlock().isPassable()) {
+                    if (loc.getBlock().getBlockData() instanceof Slab){
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("BOTTOM")){
+                            return;
+                        }
+                    }
+
+                    if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                        return;
+                    }
+
+                    Bukkit.getScheduler().runTask(Main.instance, () -> {
+                        ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    });
+                }
+            }
+            if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getBlockData() instanceof Slab){
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (!slab.getType().toString().equals("DOUBLE")){
+                        return;
+                    }
+                }
+                Bukkit.getScheduler().runTask(Main.instance, () -> {
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                });
+                return;
             }
         }
     }
@@ -284,5 +319,12 @@ public class VehicleMovement1_17 {
         Bukkit.getScheduler().runTask(Main.instance, () -> {
             stand.setLocation(loc.getX(), loc.getY(), loc.getZ(), seatas.getLocation().getYaw() + 15, seatas.getLocation().getPitch());
         });
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,7 +6,7 @@
 #---------------------------------------------------------------------------
 
 # Blijf hiervan af want je plugin gaat sowieso kapot als je dit aanpast!
-Config-Versie: 2.1.1
+Config-Versie: 2.2.1
 
 # Dont change this, else your plugin can be broke.
 messagesLanguage: ns
@@ -52,6 +52,10 @@ hornCooldown: 5
 
 # Type of horn, later will be added that you can change the types for each car
 hornType: "minetopiaclassic.horn1"
+
+# Whether the vehicles should be able to drive up hills by slabs ('slabs') or full blocks ('blocks').
+# Default: 'slabs' (If your input is not recognized, the default shall be used.)
+driveUp: 'slabs'
 
 # Een lijst met toegestane blokken om een auto op te kunnen plaatsen
 blockWhitelist:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: MTVehicles
-version: 2.1.1
+version: 2.2.1
 main: nl.mtvehicles.core.Main
 api-version: 1.13
 commands:


### PR DESCRIPTION
Before the changes, only smooth stone and stone bricks slabs could be driven on. I believe I have changed it so that one can drive on any slab, including double and top ones.

Also, if grass blocks were not whitelisted, one could right click and make farmlands - so I fixed it too.