### PR TITLE
Trunk dupe fix

### DIFF
--- a/src/main/java/nl/mtvehicles/core/infrastructure/vehicle/VehicleUtils.java
+++ b/src/main/java/nl/mtvehicles/core/infrastructure/vehicle/VehicleUtils.java
@@ -462,6 +462,10 @@ public final class VehicleUtils {
         }
     }
 
+    public static boolean isTrunkInventoryOpen(Player p, String license) {
+        return openedTrunk.containsKey(p) && openedTrunk.get(p).equals(license);
+    }
+
     /**
      * Check whether a player is inside a vehicle
      * @param p Player

--- a/src/main/java/nl/mtvehicles/core/listeners/VehicleEntityListener.java
+++ b/src/main/java/nl/mtvehicles/core/listeners/VehicleEntityListener.java
@@ -57,13 +57,8 @@ public class VehicleEntityListener extends MTVListener {
             callAPI();
             if (isCancelled()) return;
 
-            if (VehicleUtils.isTrunkInventoryOpen(player, license)) {
-                event.setCancelled(true);
-                return;
-            }
-
-            VehicleUtils.openTrunk(player, api.getLicensePlate());
             event.setCancelled(true);
+            if (!VehicleUtils.isTrunkInventoryOpen(player, license)) VehicleUtils.openTrunk(player, api.getLicensePlate());
             return;
         }
 

--- a/src/main/java/nl/mtvehicles/core/listeners/VehicleEntityListener.java
+++ b/src/main/java/nl/mtvehicles/core/listeners/VehicleEntityListener.java
@@ -57,6 +57,11 @@ public class VehicleEntityListener extends MTVListener {
             callAPI();
             if (isCancelled()) return;
 
+            if (VehicleUtils.isTrunkInventoryOpen(player, license)) {
+                event.setCancelled(true);
+                return;
+            }
+
             VehicleUtils.openTrunk(player, api.getLicensePlate());
             event.setCancelled(true);
             return;


### PR DESCRIPTION
**Issue description**
There is a duplication bug on all minecraft versions. When using an auto clicker to open a trunk, remove an item, and then open the trunk again, all items remains in the trunk

**How to reproduce**
The bug occurs when a player uses an auto clicker to open a trunk and remove an item. Upon opening the trunk again, the previously removed item is still present in the trunk. This issue could potentially lead to duplication exploits and disrupt gameplay.

**Dupe Showcase**
Here is a video demonstrating the issue: [Video Link](https://youtu.be/W2NmNa8-KuA?t=102)

**Solution**
I have discovered that when opening the trunk with an auto clicker, it triggers the code multiple times. I have implemented a check to prevent the code from being executed again if the player is already inside the trunk. This fix resolves the duplication issue.