### PR TITLE
trunk dupe fix

### DIFF
--- a/src/main/java/nl/mtvehicles/core/listeners/inventory/InventoryCloseListener.java
+++ b/src/main/java/nl/mtvehicles/core/listeners/inventory/InventoryCloseListener.java
@@ -1,6 +1,7 @@
 package nl.mtvehicles.core.listeners.inventory;
 
 import nl.mtvehicles.core.events.inventory.InventoryCloseEvent;
+import nl.mtvehicles.core.infrastructure.dataconfig.VehicleDataConfig;
 import nl.mtvehicles.core.infrastructure.enums.InventoryTitle;
 import nl.mtvehicles.core.infrastructure.utils.LanguageUtils;
 import nl.mtvehicles.core.infrastructure.utils.TextUtils;
@@ -42,7 +43,7 @@ public class InventoryCloseListener extends MTVListener {
             VehicleUtils.openedTrunk.remove(player);
             List<ItemStack> chest = new ArrayList<>();
             chest.addAll(Arrays.asList(event.getInventory().getContents()));
-            ConfigModule.vehicleDataConfig.getConfig().set("vehicle." + license + ".kofferbakData", chest);
+            ConfigModule.vehicleDataConfig.set(license, VehicleDataConfig.Option.TRUNK_DATA, chest);
             ConfigModule.vehicleDataConfig.save();
         }
 


### PR DESCRIPTION
This pull request addresses an issue in the trunk that leads to item duplication.

**Steps to Reproduce the Issue:**
1. Place an item in the trunk.
2. Use an autoclicker to spam the trunk rapidly.
3. Remove the items from the trunk.
4. The items will be duplicated.

**Demonstration of the Duplication Issue:** [here](https://youtube.com/watch?v=W2NmNa8-KuA)

**Proposed Solution:**
Upon investigating the source code, I identified the root cause of the problem: the loading and saving functions were not using the same data entry in the config.

Load data function call:
```
ConfigModule.vehicleDataConfig.get(license, VehicleDataConfig.Option.TRUNK_DATA);
```
Save data function call:
```
ConfigModule.vehicleDataConfig.getConfig().set("vehicle." + license + ".kofferbakData", chest);
```

By changing the save data function call, the problem disappeared.